### PR TITLE
Send session request with session key from SignUp page

### DIFF
--- a/src/components/SignIn/SignIn.tsx
+++ b/src/components/SignIn/SignIn.tsx
@@ -19,52 +19,56 @@ export type SignInProps = Omit<ModalProps, 'overlay' | 'zIndex'>;
 
 export function sessionReducer(state: any, action: any): any {
   switch (action.type) {
-    case "SIGNIN":
-      return {
-         ...state,
-	sessionKey: action.sessionKey,
-      };
-    case "LOGOUT":
+    case 'SIGNIN':
       return {
         ...state,
-	sessionKey: null,
+        sessionKey: action.sessionKey,
+      };
+    case 'LOGOUT':
+      return {
+        ...state,
+        sessionKey: null,
       };
     default:
       return state;
   }
-};
-export let sessionKey: string;// TODO store the sessionKey in a nicer way
+}
+export let sessionKey: string; // TODO store the sessionKey in a nicer way
 
 export function SignIn(props: SignInProps): React.ReactElement {
-  let emailValue: string = '';
+  const [email, setEmail] = React.useState('');
 
-  const [sessionState, sessionDispatch] = React.useReducer(sessionReducer, null);// null for initial state
+  const [sessionState, sessionDispatch] = React.useReducer(sessionReducer, {});
 
-  const emailSignIn = function(event: React.FormEvent) {
+  const emailSignIn = function (event: React.FormEvent) {
     const requestOptions = {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email: emailValue })
-      };
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: email }),
+    };
     try {
       fetch('http://localhost:3001/v1/auth/signin', requestOptions)
-          .then(response => response.json())
-          .then(data => {
-            sessionKey = data.key;
-            console.log('fuck it heres the session key ' + sessionKey);
-	    sessionDispatch({type: 'SIGNIN', sessionKey});
-	  });
+        .then((response) => response.json())
+        .then((data) => {
+          sessionKey = data.key;
+          console.log('fuck it heres the session key ' + sessionKey);
+          sessionDispatch({ type: 'SIGNIN', sessionKey });
+        });
     } catch (err) {
       console.log(err);
     }
     // We don't need the page to reload.
     event.preventDefault();
-  }
+  };
 
-  const fieldChangeHandler = function(value: string, id?: string, setError?: (id: string, message: string) => void, clearError?: (id: string) => void) {
-    console.log('value: ' + value + ' id: ' + id);
-    emailValue = value;
-  }
+  const fieldChangeHandler = function (
+    value: string,
+    id?: string,
+    setError?: (id: string, message: string) => void,
+    clearError?: (id: string) => void
+  ) {
+    setEmail(value);
+  };
 
   return (
     <Modal
@@ -96,13 +100,10 @@ export function SignIn(props: SignInProps): React.ReactElement {
           name="email"
           placeholder="Email"
           prefix={<Icon src={Email} size="smaller" />}
-	  onChange={fieldChangeHandler}
+          onChange={fieldChangeHandler}
           autoComplete
         />
-        <Button
-	  type="submit"
-          className={styles.Submit}
-        >
+        <Button type="submit" className={styles.Submit}>
           Sign In
         </Button>
       </Form>

--- a/src/components/SignIn/SignIn.tsx
+++ b/src/components/SignIn/SignIn.tsx
@@ -17,33 +17,55 @@ import styles from './SignIn.module.scss';
 
 export type SignInProps = Omit<ModalProps, 'overlay' | 'zIndex'>;
 
-let emailValue: string = '';
+export function sessionReducer(state: any, action: any): any {
+  switch (action.type) {
+    case "SIGNIN":
+      return {
+         ...state,
+	sessionKey: action.sessionKey,
+      };
+    case "LOGOUT":
+      return {
+        ...state,
+	sessionKey: null,
+      };
+    default:
+      return state;
+  }
+};
+export let sessionKey: string;// TODO store the sessionKey in a nicer way
 
-function emailSignIn(event: React.FormEvent) {
-  const requestOptions = {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: emailValue })
-    };
+export function SignIn(props: SignInProps): React.ReactElement {
+  let emailValue: string = '';
+
+  const [sessionState, sessionDispatch] = React.useReducer(sessionReducer, null);// null for initial state
+
+  const emailSignIn = function(event: React.FormEvent) {
+    const requestOptions = {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: emailValue })
+      };
     try {
       fetch('http://localhost:3001/v1/auth/signin', requestOptions)
           .then(response => response.json())
-          .then(data => console.log('fuck it heres the session key ' + JSON.stringify(data)));
+          .then(data => {
+            sessionKey = data.key;
+            console.log('fuck it heres the session key ' + sessionKey);
+	    sessionDispatch({type: 'SIGNIN', sessionKey});
+	  });
     } catch (err) {
       console.log(err);
     }
-
     // We don't need the page to reload.
     event.preventDefault();
-}
+  }
 
+  const fieldChangeHandler = function(value: string, id?: string, setError?: (id: string, message: string) => void, clearError?: (id: string) => void) {
+    console.log('value: ' + value + ' id: ' + id);
+    emailValue = value;
+  }
 
-function fieldChangeHandler(value: string, id?: string, setError?: (id: string, message: string) => void, clearError?: (id: string) => void) {
-  console.log('value: ' + value + ' id: ' + id);
-  emailValue = value;
-}
-
-export function SignIn(props: SignInProps): React.ReactElement {
   return (
     <Modal
       id="sign-in"

--- a/src/components/SignUp/SignUp.tsx
+++ b/src/components/SignUp/SignUp.tsx
@@ -9,6 +9,8 @@ import {
 } from '@gatsby-tv/components';
 import { GatsbyPlain } from '@gatsby-tv/icons';
 
+import { sessionKey } from '@src/components/SignIn';
+
 import styles from './SignUp.module.scss';
 
 export function SignUp(): React.ReactElement {
@@ -49,18 +51,21 @@ export function SignUp(): React.ReactElement {
     </div>
   );
 
+  let handleValue: string = '';
+  let nameValue: string = '';
+  // localhost:3001/v1/auth/session/:sessionkey
   const sendSignUp = function (event: React.FormEvent) {
     const requestOptions = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'emailValue' }),
+      body: JSON.stringify({ handle: handleValue, name: nameValue }),
     };
     try {
-      fetch('http://localhost:3001/v1/auth/signin', requestOptions)
+      const requestUrl = 'http://localhost:3001/v1/auth/session/' + sessionKey;
+      console.log('requestUrl :', requestUrl);
+      fetch(requestUrl, requestOptions)
         .then((response) => response.json())
-        .then((data) =>
-          console.log('fuck it heres the session key ' + JSON.stringify(data))
-        );
+        .then(data => console.log('JWT: ' + JSON.stringify(data)));// TODO store JWT
     } catch (err) {
       console.log(err);
     }
@@ -68,16 +73,21 @@ export function SignUp(): React.ReactElement {
     // We don't need the page to reload.
     event.preventDefault();
   };
+  const channelNameChanged = function(value: string, id?: string, setError?: (id: string, message: string) => void, clearError?: (id: string) => void) {
+    nameValue = value;
+  }
+  const displayNameChanged = function(value: string, id?: string, setError?: (id: string, message: string) => void, clearError?: (id: string) => void) {
+    handleValue = value;
+  }
 
   const FormMarkup = (
     <Form className={styles.Form} onSubmit={sendSignUp}>
       <Form.Field type="text" {...emailProps} className={styles.Field} />
-      <Form.Field type="text" {...channelNameProps} className={styles.Field} />
-      <Form.Field type="text" {...displayNameProps} className={styles.Field} />
+      <Form.Field type="text" onChange={channelNameChanged} {...channelNameProps} className={styles.Field} />
+      <Form.Field type="text" onChange={displayNameChanged} {...displayNameProps} className={styles.Field} />
 
       <Button
         type="submit"
-        onClick={() => alert('This has not been set up yet.')}
         className={styles.Submit}
       >
         Submit

--- a/src/components/SignUp/SignUp.tsx
+++ b/src/components/SignUp/SignUp.tsx
@@ -18,7 +18,6 @@ export function SignUp(): React.ReactElement {
     id: 'email',
     name: 'email',
     label: 'Email',
-    labelHidden: true,
     placeholder: 'Email',
     spellCheck: false,
     autoComplete: true,
@@ -28,7 +27,6 @@ export function SignUp(): React.ReactElement {
     id: 'channel',
     name: 'channel',
     label: 'Channel Name',
-    labelHidden: true,
     placeholder: 'Channel Name',
     spellCheck: false,
     autoComplete: false,
@@ -38,7 +36,6 @@ export function SignUp(): React.ReactElement {
     id: 'display',
     name: 'display',
     label: 'Display Name',
-    labelHidden: true,
     placeholder: 'Display Name',
     spellCheck: false,
     autoComplete: false,
@@ -51,21 +48,22 @@ export function SignUp(): React.ReactElement {
     </div>
   );
 
-  let handleValue: string = '';
-  let nameValue: string = '';
+  // We are mapping "name" to "Channel Name" and "handle" to "Display Name"
+  const [handle, setHandle] = React.useState('');
+  const [name, setName] = React.useState('');
   // localhost:3001/v1/auth/session/:sessionkey
   const sendSignUp = function (event: React.FormEvent) {
     const requestOptions = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ handle: handleValue, name: nameValue }),
+      body: JSON.stringify({ handle: handle, name: name }),
     };
     try {
       const requestUrl = 'http://localhost:3001/v1/auth/session/' + sessionKey;
       console.log('requestUrl :', requestUrl);
       fetch(requestUrl, requestOptions)
         .then((response) => response.json())
-        .then(data => console.log('JWT: ' + JSON.stringify(data)));// TODO store JWT
+        .then((data) => console.log('JWT: ' + JSON.stringify(data))); // TODO store JWT
     } catch (err) {
       console.log(err);
     }
@@ -73,23 +71,40 @@ export function SignUp(): React.ReactElement {
     // We don't need the page to reload.
     event.preventDefault();
   };
-  const channelNameChanged = function(value: string, id?: string, setError?: (id: string, message: string) => void, clearError?: (id: string) => void) {
-    nameValue = value;
-  }
-  const displayNameChanged = function(value: string, id?: string, setError?: (id: string, message: string) => void, clearError?: (id: string) => void) {
-    handleValue = value;
-  }
+  const channelNameChanged = function (
+    value: string,
+    id?: string,
+    setError?: (id: string, message: string) => void,
+    clearError?: (id: string) => void
+  ) {
+    setName(value);
+  };
+  const displayNameChanged = function (
+    value: string,
+    id?: string,
+    setError?: (id: string, message: string) => void,
+    clearError?: (id: string) => void
+  ) {
+    setHandle(value);
+  };
 
   const FormMarkup = (
     <Form className={styles.Form} onSubmit={sendSignUp}>
       <Form.Field type="text" {...emailProps} className={styles.Field} />
-      <Form.Field type="text" onChange={channelNameChanged} {...channelNameProps} className={styles.Field} />
-      <Form.Field type="text" onChange={displayNameChanged} {...displayNameProps} className={styles.Field} />
+      <Form.Field
+        type="text"
+        onChange={channelNameChanged}
+        {...channelNameProps}
+        className={styles.Field}
+      />
+      <Form.Field
+        type="text"
+        onChange={displayNameChanged}
+        {...displayNameProps}
+        className={styles.Field}
+      />
 
-      <Button
-        type="submit"
-        className={styles.Submit}
-      >
+      <Button type="submit" className={styles.Submit}>
         Submit
       </Button>
     </Form>

--- a/src/components/SignUp/index.ts
+++ b/src/components/SignUp/index.ts
@@ -1,1 +1,1 @@
-export * from "./SignUp";
+export * from './SignUp';

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,8 +1,8 @@
-import React from "react";
+import React from 'react';
 
-import { SignUp } from "@src/components/SignUp";
+import { SignUp } from '@src/components/SignUp';
 
-import styles from "@src/styles/SignUp.module.scss";
+import styles from '@src/styles/SignUp.module.scss';
 
 export default function SignUpPage(): React.ReactElement {
   return (


### PR DESCRIPTION
Initial working code for signing up a user from the SignUp page.

- To test, navigate to /signup.
- Click the Sign In button at the top bar.
- Enter an email and click the "Sign In" button. This will send a request to the backend to retrieve a session key.
- Press the Escape key to close that modal.
- Fill out the fields of the SignUp page.
- Click the "Submit" button.
- This will send a request to the backend to sign up that user. The JWT will be logged to the console.