### PR TITLE
Fixed broken figures when IPFS fails to load images

### DIFF
--- a/packages/components/lib/components/Image/Image.scss
+++ b/packages/components/lib/components/Image/Image.scss
@@ -1,5 +1,9 @@
 @use 'styles' as *;
 
+.Viewport {
+  width: 100%;
+}
+
 .Image {
   @include expand();
   display: block;

--- a/packages/components/lib/components/Image/Image.tsx
+++ b/packages/components/lib/components/Image/Image.tsx
@@ -38,9 +38,11 @@ function ImageURL(props: ImageURLProps): React.ReactElement {
 
   useEffect(() => setLoading(true), [imgProps.src]);
 
+  const classes = classNames(className, styles.Viewport);
+
   return (
     <Viewport
-      className={className}
+      className={classes}
       placeholder
       rounded={rounded}
       overlay={overlay}


### PR DESCRIPTION
When images that are being fetched from IPFS fail to load, the figures containing the images appear broken in certain flex boxes. This PR fixes that by setting the width's to 100%.