### PR TITLE
NGINX dockerfile serve/redirect requests #20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,24 +16,24 @@ FROM node:alpine AS builder
 WORKDIR /app
 COPY . .
 COPY --from=deps /app .
-RUN yarn build
+RUN yarn export
 
-FROM node:alpine
-WORKDIR /app
-ENV NODE_ENV production
+FROM nginx:alpine
 
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nextjs -u 1001
+# Remove default site
+RUN rm -rf /usr/share/nginx/html/*
 
-COPY --from=packages /app .
-COPY --from=builder /app/.yarn .yarn
-COPY --from=builder /app/.pnp.js .
-COPY --from=builder /app/next.config.js .
-COPY --from=builder /app/public public
-COPY --from=builder --chown=nextjs:nodejs /app/.next .next
+# Copy over prod react nextjs build
+COPY --from=builder /app/out /usr/share/nginx/html
 
-USER nextjs
+# Handle NGINX environment variable templating with envsubst
+# The entrypoint script will fill this template and copy the configuration to NGINX
+COPY nginx.conf /etc/nginx/nginx.conf.template
+COPY docker-entrypoint.sh /usr/bin
+
+RUN chmod +x /usr/bin/docker-entrypoint.sh
 
 EXPOSE 3000
 
-CMD ["yarn", "start"]
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ push:
 run:
 	docker run \
 		-p 3000:3000 \
-		--env-file .env.local \
-		--rm -it $(APP_NAME):latest
+		--env-file default.env.local \
+		--rm -it gatsbytv/$(APP_NAME):latest

--- a/default.env.local
+++ b/default.env.local
@@ -1,0 +1,1 @@
+PUBLIC_WESTEGG_URL=http://localhost:3001

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -eu
+
+envsubst '${PUBLIC_WESTEGG_URL}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+exec "$@"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,20 @@
+worker_processes 4;
+
+events { worker_connections 1024; }
+
+http {
+    server {
+        listen 3000;
+        root /usr/share/nginx/html;
+        include /etc/nginx/mime.types;
+
+        location / {
+            try_files $uri /index.html;
+        }
+
+        # Westegg api route redirects
+        location ~ /api/(.*) {
+            return 301 ${PUBLIC_WESTEGG_URL}/$1;
+        }
+    }
+}


### PR DESCRIPTION
Changelog:
* Serve frontend on 3000 from NGINX /
* Redirect /api requests to PUBLIC_WESTEGG_URL environment variable
* Fix small bug in make run that didn't use full tag