### PR TITLE
refactor: removed default ipfs node creation from useIPFSContext

### DIFF
--- a/packages/utilities/lib/ipfs/context.ts
+++ b/packages/utilities/lib/ipfs/context.ts
@@ -2,10 +2,7 @@
 
 import { createContext } from 'react';
 
-export interface IPFSContextType {
-  readonly ipfs: any;
-  readonly error: Error | null;
-}
+export type IPFSContextType = any;
 
 export const IPFSContext = createContext<IPFSContextType | undefined>(
   undefined

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,8 @@
-import { ReactElement } from 'react';
+import { useState, useEffect, ReactElement } from 'react';
 import Head from 'next/head';
 import { AppProps } from 'next/app';
 import { SWRConfig } from 'swr';
+import * as IPFS from 'ipfs';
 import { AppProvider } from '@gatsby-tv/components';
 import { useIPFSContext, IPFSContext } from '@gatsby-tv/utilities';
 import '@gatsby-tv/components/dist/styles.css';
@@ -23,11 +24,22 @@ export default function AppPage({
   Component,
   pageProps,
 }: AppProps): ReactElement {
+  const [ipfs, setIPFS] = useState<any>(undefined);
   const channelContext = useChannelModalContext();
   const sessionContext = useSessionContext();
+
   const nodeContext = useIPFSContext(
+    ipfs,
     process.env.NEXT_PUBLIC_BOOTSTRAP_NODES?.split(',').filter(Boolean)
   );
+
+  useEffect(() => {
+    async function init() {
+      setIPFS(await IPFS.create({ repo: '/ipfs/gatsby' }));
+    }
+
+    init();
+  }, []);
 
   const HeaderMarkup = (
     <Head>


### PR DESCRIPTION
There are several means to produce an IPFS node in the js-ipfs ecosystem.
I refactored the `useIPFSContext` hook to support those different types of clients.